### PR TITLE
fix(github-actions): Correctly install bundle dependencies

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -27,7 +27,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2.4'
-          bundler-cache: true
+
+      - name: Install dependencies
+        run: bundle install
 
       - name: Update all dependencies
         run: bundle update


### PR DESCRIPTION
The "Update Ruby Dependencies" workflow was failing because it used `bundler-cache: true` in the `ruby/setup-ruby` action. This option runs `bundle install` in deployment mode, which prevents `Gemfile.lock` from being updated if it's out of sync with `Gemfile`.

This change fixes the workflow by:
- Removing `bundler-cache: true` from the `ruby/setup-ruby` step.
- Adding an explicit `bundle install` step.

This ensures that dependencies are installed without freezing the lockfile, allowing the subsequent `bundle update` step to succeed.